### PR TITLE
Update Makefile with venv activation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 # App: Streamlit App
 # Package: root
 # File: Makefile
-# Version: 0.0.5
+# Version: 0.0.7
 # Author: Bobwares
-# Date: 2025-06-07 22:22:00 UTC
+# Date: 2025-06-07 22:46:19 UTC
 # Description: CLI commands for development.
 #
 
@@ -12,12 +12,12 @@ venv:
 	python3 -m venv venv
 	. venv/bin/activate && pip install -r requirements.txt
 
-install:
-	pip install -r requirements.txt
+install: venv
+	. venv/bin/activate && pip install -r requirements.txt
 
-run:
-	streamlit run src/app.py
+run: venv
+	. venv/bin/activate && streamlit run src/app.py
 
-test:
-	pytest -q
+test: venv
+	. venv/bin/activate && pytest -q
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ Alternatively, use the Makefile helpers:
 
 ```bash
 make venv
-source venv/bin/activate
 make install
 make run
 make test
 ```
+
+The `run` and `test` targets automatically activate the virtual environment.

--- a/version.md
+++ b/version.md
@@ -20,3 +20,10 @@
 - Changed virtual environment directory to `venv`.
 - Updated Makefile and README to match.
 - Updated `.gitignore` accordingly.
+
+## 0.0.6 - 2025-06-07
+- Enhanced Makefile to activate the virtual environment automatically when running
+  the application and tests.
+
+## 0.0.7 - 2025-06-07
+- Updated the install target to also activate the virtual environment.


### PR DESCRIPTION
## Summary
- run and test targets now activate the virtual environment automatically
- document the change in the changelog
- also activate the virtual environment for the install target

## Testing
- `pytest -q`
- `make test` *(fails: Could not find streamlit due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_6844bffc6b60832db1bc24b899d42528